### PR TITLE
Add simple WebSocket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# WebSocket Client
+
+Simple TypeScript program to connect to a WebSocket server and send messages.
+
+## Usage
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the client:
+
+```bash
+npm start
+```
+
+The client connects to the following WebSocket URL:
+
+```
+wss://ws-deposito-remoto-sucursales-back.canales-sbx.noprodcomafi.aws/?origin=DRS-SOFTWARE&scanner_id=ewee&draft_id=eeee
+```
+
+After connection, type messages and press <kbd>Enter</kbd> to send. Incoming messages will be printed to the console.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "websocket-client",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "ws": "^8.13.0"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,34 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+import WebSocket from 'ws';
+import readline from 'readline';
+
+const url = 'wss://ws-deposito-remoto-sucursales-back.canales-sbx.noprodcomafi.aws/?origin=DRS-SOFTWARE&scanner_id=ewee&draft_id=eeee';
+
+const ws = new WebSocket(url);
+
+ws.on('open', () => {
+  console.log('Connected to WebSocket server. Type messages and press enter to send.');
+});
+
+ws.on('message', (data) => {
+  console.log('Received:', data.toString());
+});
+
+ws.on('close', () => {
+  console.log('Connection closed');
+  process.exit(0);
+});
+
+ws.on('error', (err) => {
+  console.error('WebSocket error:', err);
+});
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.on('line', (input) => {
+  ws.send(input);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add instructions in README for running the websocket client
- add package.json with dependencies for ws and ts-node
- add TypeScript implementation to connect to the specified WebSocket server
- set up TypeScript compiler options

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841b2d16a84832d86ebf2f21bb3ce47